### PR TITLE
Fix Windows clipboard paste mojibake for CJK search text

### DIFF
--- a/visual/computer/computer_action_executor.py
+++ b/visual/computer/computer_action_executor.py
@@ -172,7 +172,9 @@ class ComputerActionExecutor:
             env["LC_ALL"] = "en_US.UTF-8"
             subprocess.run(["pbcopy"], input=text.encode("utf-8"), env=env, check=True)
         elif system == "Windows":
-            subprocess.run(["clip"], input=text.encode("utf-16le"), check=True)
+            # clip.exe expects UTF-16 with BOM; utf-16le alone is misread as ANSI on
+            # localized Windows and pastes mojibake into Search / text fields.
+            subprocess.run(["clip"], input=text.encode("utf-16"), check=True)
         else:
             subprocess.run(["xclip", "-selection", "clipboard"], input=text.encode("utf-8"), check=True)
 


### PR DESCRIPTION
## Problem

`ComputerActionExecutor._type_text()` pastes text on Windows via `clip.exe` and Ctrl+V. The clipboard was filled with `text.encode("utf-16le")` (UTF-16 **without** BOM).

On localized Windows (e.g. code page 936 / GBK), `clip.exe` can treat that byte stream as ANSI/system code page instead of Unicode. Pasting into the taskbar search box or other text fields then shows **mojibake** (e.g. `企业微信` → `吅OON胜醇`).
<img width="417" height="190" alt="image" src="https://github.com/user-attachments/assets/f240519e-beb4-4af3-9942-a827465b13af" />

Agent output is unaffected: logs and `action_desc` still show the correct Chinese string (`type: 企业微信`). The bug is in **local input**, not model responses.

## Solution

Encode clipboard input as **UTF-16 with BOM** using Python's `utf-16` codec (adds `FF FE` BOM + UTF-16LE payload), which `clip.exe` recognizes as Unicode.

## Changes

```python
# visual/computer/computer_action_executor.py — _type_text(), Windows branch

# Before
subprocess.run(["clip"], input=text.encode("utf-16le"), check=True)

# After
# clip.exe expects UTF-16 with BOM; utf-16le alone is misread as ANSI on
# localized Windows and pastes mojibake into Search / text fields.
subprocess.run(["clip"], input=text.encode("utf-16"), check=True)
```

Typing still uses clipboard + Ctrl+V (unchanged); only the Windows clipboard encoding is fixed. macOS (`pbcopy` / UTF-8) and Linux (`xclip`) paths are unchanged.

## Files Changed

- `visual/computer/computer_action_executor.py`

## Testing

- [x] On Windows 11 (GBK console, `chcp 936`), run a task that types a CJK app name into taskbar search (e.g. `企业微信`).
- [x] Confirm search box shows the correct characters, not mojibake.
- [x] Confirm macOS/Linux paste behavior is unchanged (no regression).


